### PR TITLE
feat: execute query on Ctrl+Enter / Cmd+Enter

### DIFF
--- a/src/static/app_ui.js
+++ b/src/static/app_ui.js
@@ -617,6 +617,12 @@
     dom.queryTextArea.addEventListener("keydown", (e) => {
       const key = e.key;
       if (e.isComposing) return;
+      if ((e.ctrlKey || e.metaKey) && key === "Enter") {
+        e.preventDefault();
+        const run = ns.run;
+        if (run && typeof run.handleRun === "function") run.handleRun();
+        return;
+      }
       if (e.ctrlKey || e.metaKey || e.altKey) return;
 
       if (key === "`" || key === "\"" || key === "'") {


### PR DESCRIPTION
## Summary

- Adds keyboard shortcut to execute the current query without reaching for the mouse
- \`Ctrl+Enter\` on Linux/Windows, \`Cmd+Enter\` on macOS
- Hooks into the existing \`handleRun()\` function — same path as the Run button

## Implementation

Single change in \`src/static/app_ui.js\`, in the textarea \`keydown\` handler: intercepts \`Ctrl/Cmd+Enter\` before the blanket modifier-key early-return and delegates to \`ns.run.handleRun()\`.

\`\`\`js
if ((e.ctrlKey || e.metaKey) && key === "Enter") {
  e.preventDefault();
  const run = ns.run;
  if (run && typeof run.handleRun === "function") run.handleRun();
  return;
}
\`\`\`

## Test plan

- [x] Type a query in the editor, press \`Ctrl+Enter\` (Linux/Windows) → query executes
- [x] Same with \`Cmd+Enter\` on macOS
- [x] Plain \`Enter\` still inserts a newline with auto-indent
- [x] \`Ctrl+Enter\` while a query is already running does not trigger a second run (disabled by \`updateActionButtons\`)