### PR TITLE
fix: preserve full field name in formatting errors

### DIFF
--- a/src/api_error.cpp
+++ b/src/api_error.cpp
@@ -214,7 +214,7 @@ ClickHouseErrorLocation parse_clickhouse_error_location(std::string_view msg, st
       size_t j = i;
       while (j < msg.size()) {
         char c = msg[j];
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '.' || c == ',' || c == ')') break;
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',' || c == ')') break;
         ++j;
       }
       if (j > i) {

--- a/test/api/query_types/check_query_types.py
+++ b/test/api/query_types/check_query_types.py
@@ -222,3 +222,25 @@ def assert_query_stream_ok(case_name: str, sql: str) -> None:
 )
 def test_query_stream_supports_native_edge_types(case_name: str, sql: str) -> None:
     assert_query_stream_ok(case_name, sql)
+
+
+def test_query_error_preserves_dotted_field_name_in_location() -> None:
+    sql = "SELECT missing.field FROM system.one"
+    _, events = run_query_and_collect_events(sql)
+
+    error_event = next((event for event in events if event["event"] == "error"), None)
+    assert error_event is not None, f"expected error event, got: {json.dumps(events, ensure_ascii=False, indent=2)}"
+
+    payload = error_event.get("data") or {}
+    clickhouse = payload.get("clickhouse") if isinstance(payload.get("clickhouse"), dict) else {}
+    near = clickhouse.get("near") if isinstance(clickhouse, dict) else None
+
+    assert isinstance(near, str) and near, (
+        "expected clickhouse.near in error payload\n"
+        f"payload={json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )
+    assert near == "missing.field", (
+        "expected full dotted field name in clickhouse.near\n"
+        f"near={near!r}\n"
+        f"payload={json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )


### PR DESCRIPTION
## Summary
- preserve dotted identifiers when extracting `clickhouse.near` from error messages
- avoid truncating field names like `foo.bar` to `foo`
- add a regression API test ensuring dotted names are kept in error payloads

Fixes #4