### PR TITLE
test(format): cron watcher perf probe

### DIFF
--- a/test/api/format/sql/099_cron_perf_probe.sql
+++ b/test/api/format/sql/099_cron_perf_probe.sql
@@ -1,0 +1,9 @@
+SELECT
+    profile_id
+FROM anon_probe_table
+WHERE
+    is_active = 1
+    AND profile_id IN (
+        SELECT profile_id
+        FROM anon_probe_allowlist
+    )


### PR DESCRIPTION
Draft PR de test pour mesurer latence du watcher Ollama (router-only).\n\n- Aucun fix formatter\n- Fixture fictive uniquement pour déclencher le flux de détection\n- Sera supprimée après mesure\n